### PR TITLE
Fixed casing of Component property name in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Used to host a react tree inside a Knockout app, useful for incrementally migrat
 ```html
 <div data-bind="
     reactComponent: {
-        component: MyComponent,
+        Component: MyComponent,
         props: {prop: 'propValue'}
     }
 "><!-- MyComponent will render here --></div>


### PR DESCRIPTION
I noticed that the readme had a small mistake in the casing of the `Component` property in the documentation of the `reactComponent` bindingHandler.  